### PR TITLE
Update undici to version 6.23.0 because of Issue #8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1665,9 +1665,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.21.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.2.tgz",
-      "integrity": "sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==",
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
       "engines": {
         "node": ">=18.17"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "qs": "^6.14.1"
   },
   "overrides": {
-    "undici": "6.21.2",
+    "undici": "6.23.0",
     "body-parser": "2.2.1"
   }
 }


### PR DESCRIPTION
Security: Upgrade undici to 6.23.0 (CVE-2024-27086)

Fixes unbounded decompression chain vulnerability in Node.js Fetch API responses.