### PR TITLE
Fix duplicate notifyAdminServer function declarations causing startup failures

### DIFF
--- a/src/commands/verify.js
+++ b/src/commands/verify.js
@@ -7,22 +7,6 @@ require('dotenv').config();
 
 const INTERNAL_SECRET = process.env.INTERNAL_SECRET || 'change-me-in-production';
 
-// Helper to notify admin server of changes
-async function notifyAdminServer(type) {
-  try {
-    const response = await fetch('http://web:8001/api/internal/notify-change', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ type })
-    });
-    if (!response.ok) {
-      console.warn(`⚠️ Failed to notify admin server: ${response.status}`);
-    }
-  } catch (err) {
-    console.warn('⚠️ Could not notify admin server:', err.message);
-  }
-}
-
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('verify')

--- a/src/commands/warn.js
+++ b/src/commands/warn.js
@@ -7,23 +7,6 @@ require('dotenv').config();
 
 const INTERNAL_SECRET = process.env.INTERNAL_SECRET || 'change-me-in-production';
 
-// Helper to notify admin server of changes
-async function notifyAdminServer(type) {
-  try {
-    const response = await fetch('http://web:8001/api/internal/notify-change', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ type })
-    });
-    if (!response.ok) {
-      console.warn(`⚠️ Failed to notify admin server: ${response.status}`);
-    }
-  } catch (err) {
-    // Silently fail - warn command should still work even if notification fails
-    console.warn('⚠️ Could not notify admin server:', err.message);
-  }
-}
-
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('warn')

--- a/src/events/handleInteractions.js
+++ b/src/events/handleInteractions.js
@@ -25,22 +25,6 @@ async function notifyAdminServerHelper(type) {
   return notifyAdminServer(type, INTERNAL_SECRET);
 }
 
-// Helper to notify admin server of changes
-async function notifyAdminServer(type) {
-  try {
-    const response = await fetch('http://web:8001/api/internal/notify-change', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ type })
-    });
-    if (!response.ok) {
-      console.warn(`⚠️ Failed to notify admin server: ${response.status}`);
-    }
-  } catch (err) {
-    console.warn('⚠️ Could not notify admin server:', err.message);
-  }
-}
-
 function buildDisabledRowsFrom(message) {
   if (!message?.components?.length) return [];
   return message.components.map(row => {


### PR DESCRIPTION
## Problem
The bot was failing to start with a SyntaxError due to duplicate `notifyAdminServer` function declarations in multiple files.

## Root Cause
Three files were importing `notifyAdminServer` from `src/utils/botNotifier.js` but also declaring it locally, causing identifier conflicts:
- `src/events/handleInteractions.js`
- `src/commands/verify.js`
- `src/commands/warn.js`

## Solution
Removed the duplicate local function declarations and kept the imported version from `botNotifier.js`, which properly handles the notification logic with the internal secret.

## Changes
- Removed duplicate `notifyAdminServer` function (lines 29-41) from handleInteractions.js
- Removed duplicate `notifyAdminServer` function (lines 11-23) from verify.js  
- Removed duplicate `notifyAdminServer` function (lines 11-24) from warn.js

## Impact
✅ Bot now starts successfully without SyntaxError
✅ All admin server notifications continue to work as expected
✅ No functional changes to bot behavior